### PR TITLE
Fixing android aarch, non fp16 build.

### DIFF
--- a/gemm-f16/src/gemm.rs
+++ b/gemm-f16/src/gemm.rs
@@ -1079,12 +1079,19 @@ pub mod f16 {
         }
 
         #[cfg(target_arch = "aarch64")]
+        #[cfg(target_feature = "fp16")]
         {
             if gemm_common::feature_detected!("neon") {
                 neon::gemm_basic
             } else {
                 scalar::gemm_basic
             }
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        #[cfg(not(target_feature = "fp16"))]
+        {
+            scalar::gemm_basic
         }
 
         #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
@@ -1147,6 +1154,7 @@ pub mod f16 {
     }
 
     #[cfg(target_arch = "aarch64")]
+    #[cfg(target_feature = "fp16")]
     mod neon {
         use super::*;
         use crate::microkernel::neon::f16::{MR_DIV_N, NR, UKR};

--- a/gemm-f16/src/microkernel.rs
+++ b/gemm-f16/src/microkernel.rs
@@ -344,6 +344,7 @@ pub mod neon {
         }
     }
 
+    #[cfg(target_feature = "fp16")]
     pub mod f16 {
         use core::arch::{aarch64::uint16x8_t, asm};
         use core::mem::transmute;


### PR DESCRIPTION
To reproduce:

```
rustup target add aarch64-linux-android
cargo build --target=aarch64-linux-android
```